### PR TITLE
Authors migrations

### DIFF
--- a/armstrong/core/arm_content/fields/authors.py
+++ b/armstrong/core/arm_content/fields/authors.py
@@ -99,3 +99,14 @@ class AuthorsField(models.ManyToManyField):
     def contribute_to_class(self, cls, name):
         super(AuthorsField, self).contribute_to_class(cls, name)
         setattr(cls, self.name, AuthorsDescriptor(self))
+
+    def south_field_triple(self):
+        from south.modelsinspector import introspector
+        field_class = "%s.%s" % (self.__class__.__module__,
+                self.__class__.__name__)
+        args, kwargs = introspector(self)
+        kwargs.update({
+            'override_field_name': self.override_field_name,
+            'extra_field_name': self.extra_field_name,
+        })
+        return (field_class, args, kwargs)

--- a/armstrong/core/arm_content/fields/authors.py
+++ b/armstrong/core/arm_content/fields/authors.py
@@ -90,11 +90,13 @@ class AuthorsDescriptor(object):
 
 
 class AuthorsField(models.ManyToManyField):
-    def __init__(self, override_field_name='authors_override',
+    def __init__(self, to=None, override_field_name='authors_override',
             extra_field_name='authors_extra', **kwargs):
+        if not to:
+            to = User
         self.override_field_name = override_field_name
         self.extra_field_name = extra_field_name
-        super(AuthorsField, self).__init__(User, **kwargs)
+        super(AuthorsField, self).__init__(to=to, **kwargs)
 
     def contribute_to_class(self, cls, name):
         super(AuthorsField, self).contribute_to_class(cls, name)

--- a/armstrong/core/arm_content/fields/authors.py
+++ b/armstrong/core/arm_content/fields/authors.py
@@ -106,7 +106,7 @@ class AuthorsField(models.ManyToManyField):
                 self.__class__.__name__)
         args, kwargs = introspector(self)
         kwargs.update({
-            'override_field_name': self.override_field_name,
-            'extra_field_name': self.extra_field_name,
+            'override_field_name': "'%s'" % self.override_field_name,
+            'extra_field_name': "'%s'" % self.extra_field_name,
         })
         return (field_class, args, kwargs)

--- a/armstrong/core/arm_content/tests/_utils.py
+++ b/armstrong/core/arm_content/tests/_utils.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 import fudge
 import random
+import unittest
 
 from .arm_content_support.models import Article, Video
 from ..publication.constants import PUB_STATUSES

--- a/armstrong/core/arm_content/tests/fields/authors.py
+++ b/armstrong/core/arm_content/tests/fields/authors.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from django.contrib.auth.models import User
+from django.db import models
 import fudge
 try:
     import south
@@ -168,3 +170,14 @@ class AuthorsFieldTestCase(TestCase):
             }
         )
         self.assertEqual(field.south_field_triple(), expected)
+
+    def test_defaults_to_being_related_to_base_user(self):
+        field = authors.AuthorsField()
+        self.assertEqual(field.rel.to, User)
+
+    def test_can_relate_to_custom_user(self):
+        class MyUser(models.Model):
+            pass
+
+        field = authors.AuthorsField(to=MyUser)
+        self.assertEqual(field.rel.to, MyUser)

--- a/armstrong/core/arm_content/tests/fields/authors.py
+++ b/armstrong/core/arm_content/tests/fields/authors.py
@@ -1,5 +1,9 @@
 # coding=utf-8
 import fudge
+try:
+    import south
+except ImportError:
+    south = False
 
 from ..arm_content_support.models import AuthoredModelWithConfiguredOverride
 from ..arm_content_support.models import AuthoredModelWithContentionalOverride
@@ -149,3 +153,18 @@ class AuthorsFieldTestCase(TestCase):
         expected = "%s, %s%s" % (bob.get_full_name(), alice.get_full_name(),
                 extra)
         self.assertEqual(str(article.authors), expected)
+
+    @unittest.skipIf(south is False, "south not installed")
+    def test_provides_south_field_triple(self):
+        field = authors.AuthorsField()
+        expected = (
+            "%s.%s" % (field.__class__.__module__, field.__class__.__name__),
+            [],
+            {
+                "to": "orm['auth.User']",
+                "override_field_name": "authors_override",
+                "extra_field_name": "authors_extra",
+                "symmetrical": "False",
+            }
+        )
+        self.assertEqual(field.south_field_triple(), expected)

--- a/armstrong/core/arm_content/tests/fields/authors.py
+++ b/armstrong/core/arm_content/tests/fields/authors.py
@@ -162,8 +162,8 @@ class AuthorsFieldTestCase(TestCase):
             [],
             {
                 "to": "orm['auth.User']",
-                "override_field_name": "authors_override",
-                "extra_field_name": "authors_extra",
+                "override_field_name": "'authors_override'",
+                "extra_field_name": "'authors_extra'",
                 "symmetrical": "False",
             }
         )


### PR DESCRIPTION
The `AuthorsField` can't support migrations w/o this patch.
