### PR TITLE
Fix tests

### DIFF
--- a/armstrong/core/arm_content/tests/__init__.py
+++ b/armstrong/core/arm_content/tests/__init__.py
@@ -1,31 +1,5 @@
-from ._utils import TestCase, create_random_article, create_random_video
-from .arm_content_support.models import BaseContent, Article, Video
 from .admin import *
 from .fields import *
 from .mixins import *
 from .models import *
 from .video import *
-
-
-class BaseContentTestCase(TestCase):
-    def test_can_add_content(self):
-        article = create_random_article()
-        Article.objects.get(id=article.id)
-
-    def test_can_fetch_combined_queryset(self):
-        create_random_article()
-        create_random_video()
-        create_random_article()
-        create_random_video()
-
-        self.assertEqual(BaseContent.objects.count(), 4)
-        for item in BaseContent.objects.all():
-            self.assertFalse(item.__class__ == BaseContent)
-
-        articles = [item for item in BaseContent.objects.all() if
-            item.__class__ == Article]
-        self.assertEqual(len(articles), 2)
-
-        videos = [item for item in BaseContent.objects.all() if
-            item.__class__ == Video]
-        self.assertEqual(len(videos), 2)

--- a/armstrong/core/arm_content/tests/_utils.py
+++ b/armstrong/core/arm_content/tests/_utils.py
@@ -8,7 +8,6 @@ from django.utils import unittest
 import fudge
 import random
 
-from .arm_content_support.models import Article, Video
 from ..mixins.publication import PUB_STATUSES
 
 
@@ -100,30 +99,6 @@ class TestCase(DjangoTestCase):
 
     def assertDoesNotHave(self, obj, attr, **kwargs):
         self.assertFalse(hasattr(obj, attr), **kwargs)
-
-
-def create_random_article(**options):
-    random_int = random.randint(1000, 9999)
-    data = {
-        'pub_date': datetime.now(),
-        'pub_status': PUB_STATUSES['Published'],
-        'title': 'Random Article %s' % random_int,
-        'body': str(random_int),
-    }
-    data.update(options)
-    return Article.objects.create(**data)
-
-
-def create_random_video(**options):
-    random_int = random.randint(1000, 9999)
-    data = {
-        'pub_date': datetime.now(),
-        'pub_status': PUB_STATUSES['Published'],
-        'title': 'Random Article %s' % random_int,
-        'youtube_id': str(random_int),
-    }
-    data.update(options)
-    return Video.objects.create(**data)
 
 
 def generate_random_user():

--- a/armstrong/core/arm_content/tests/arm_content_support/models.py
+++ b/armstrong/core/arm_content/tests/arm_content_support/models.py
@@ -1,6 +1,5 @@
 from django.contrib.auth.models import User
 from django.db import models
-from polymorphic import PolymorphicModel
 
 from ...fields import AuthorsField
 from ...fields import EmbeddedVideoField
@@ -9,13 +8,7 @@ from ...mixins import PublicationMixin
 from ...models import ContentBase
 
 
-# for backwards compatibility -- should be removed
-class BaseContent(PolymorphicModel, PublicationMixin):
-    title = models.CharField(max_length=255)
-
-
-class ConcreteContent(ContentBase):
-    pass
+from armstrong.apps.content.models import Content as ConcreteContent
 
 
 class ConcreteArticle(ConcreteContent):
@@ -25,13 +18,6 @@ class ConcreteArticle(ConcreteContent):
 class ConcreteCommentary(ConcreteContent):
     pass
 
-
-class Article(BaseContent):
-    body = models.TextField()
-
-
-class Video(BaseContent):
-    youtube_id = models.CharField(max_length=30)
 
 
 class SimpleVideoModel(models.Model):

--- a/fabfile/__init__.py
+++ b/fabfile/__init__.py
@@ -20,3 +20,4 @@ settings = {
 
 main_app = "arm_content"
 tested_apps = ("arm_content_support", "arm_content", )
+pip_install_first = True

--- a/fabfile/__init__.py
+++ b/fabfile/__init__.py
@@ -8,6 +8,7 @@ settings = {
         'django.contrib.auth',
         'django.contrib.contenttypes',
         'django.contrib.sessions',
+        'armstrong.apps.content',
         'armstrong.core.arm_content',
         'armstrong.core.arm_content.tests.arm_content_support',
         'armstrong.core.arm_sections',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,4 +3,4 @@ south
 django-taggit>=0.9.3
 django-model-utils==0.6.0
 django-reversion==1.4
--e git://github.com/armstrongcms/armstrong.core.arm_sections.git#egg=armstrong.core.arm_sections
+armstrong.core.arm_sections>=0.1.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,11 +1,8 @@
+-r ./base.txt
 -e git://github.com/domain51/d51.django.virtualenv.base#egg=d51.django.virtualenv.base
 -e git://github.com/domain51/d51.django.virtualenv.test_runner#egg=d51.django.virtualenv.test_runner
 -e git://github.com/tswicegood/fabric#egg=fabric
--e git://github.com/armstrongcms/armstrong.dev#egg=armstrong.dev
 coverage
 fudge
-
-# django_polymorphic is what we'll recommend for creating a parent model with
-# common fields for querying across the child content types. Our tests include
-# that use case.
--e git://github.com/bconstantin/django_polymorphic.git@2c47db8fcc284a92d2c9769ba503603fbea92660#egg=django_polymorphic
+armstrong.apps.content
+armstrong.dev>=1.2.0


### PR DESCRIPTION
None of this is needed any longer.  Originally, we didn't have any concrete implementations of a content class.  For testing purposes we can assume that `armstrong.apps.content` is around (for now), so we're
relying on it.

The potential problem with this commit is for people who attempt to test `arm_content` via Django's test runner without having the main `armstrong.apps.content` app installed.  Opening a ticket to deal with that.
