### PR TITLE
fixes a problem I was seeing when trying to use a subclass of ContentBase

### DIFF
--- a/armstrong/core/arm_content/models.py
+++ b/armstrong/core/arm_content/models.py
@@ -31,7 +31,7 @@ class ContentBase(mixins.AuthorsMixin, mixins.PublicationMixin, models.Model):
 
     primary_section = models.ForeignKey(Section, null=True)
     sections = models.ManyToManyField(Section, null=True, blank=True,
-            related_name="alternates")
+            related_name="%(class)s_alternates")
 
     tags = TaggableManager()
     with_section = SectionSlugManager()


### PR DESCRIPTION
fixes
Error: One or more models did not validate:
content.content: Accessor for m2m field 'sections' clashes with related
m2m field 'Section.alternates'. Add a related_name argument to the
definition for 'sections'.
content.content: Reverse query name for m2m field 'sections' clashes
with related m2m field 'Section.alternates'. Add a related_name argument
to the definition for 'sections'.
audio.audiopublication: Accessor for m2m field 'sections' clashes with
related m2m field 'Section.alternates'. Add a related_name argument to
the definition for 'sections'.
audio.audiopublication: Reverse query name for m2m field 'sections'
clashes with related m2m field 'Section.alternates'. Add a related_name
argument to the definition for 'sections'.

when subclassing ContentBase
