### PR TITLE
Add an `is_published()` method for Content using the SimplePublicationMixin

### DIFF
--- a/armstrong/core/arm_content/mixins/publication.py
+++ b/armstrong/core/arm_content/mixins/publication.py
@@ -19,6 +19,11 @@ class SimplePublicationMixin(models.Model):
         choices=PUB_STATUS_CHOICES, help_text=(
             u'Only published items will appear on the site'))
 
+    @property
+    def is_published(self):
+        return self.pub_date <= datetime.now() \
+            and self.pub_status == "P"
+
     class Meta:
         abstract = True
 

--- a/armstrong/core/arm_content/tests/mixins/publication.py
+++ b/armstrong/core/arm_content/tests/mixins/publication.py
@@ -7,17 +7,30 @@ from ..arm_content_support.models import ConcreteArticle
 import datetime
 
 class PublicationManagerTestCase(ArmContentTestCase):
+    def setUp(self):
+        self.published = ConcreteArticle.objects.create(
+                title="Published",
+                pub_date=datetime.datetime.now()-datetime.timedelta(days=1),
+                pub_status='P'
+            )
+        self.draft_art = ConcreteArticle.objects.create(
+                title="Not Published",
+                pub_date=datetime.datetime.now()-datetime.timedelta(days=1),
+                pub_status='D'
+            )
+        self.scheduled = ConcreteArticle.objects.create(
+                title="Future Published",
+                pub_date=datetime.datetime.now()+datetime.timedelta(days=1),
+                pub_status='P'
+            )
+
     def test_published_manager_only_pulls_published_content(self):
-        published = ConcreteArticle.objects.create(title="Published",
-                                           pub_date=datetime.datetime.now()-datetime.timedelta(days=1),
-                                           pub_status='P')
-        draft_art = ConcreteArticle.objects.create(title="Not Published",
-                                           pub_date=datetime.datetime.now()-datetime.timedelta(days=1),
-                                           pub_status='D')
-        scheduled = ConcreteArticle.objects.create(title="Future Published",
-                                           pub_date=datetime.datetime.now()+datetime.timedelta(days=1),
-                                           pub_status='P')
         all_published = ConcreteArticle.published.all().select_subclasses()
-        self.assertTrue(published in all_published)
-        self.assertTrue(not draft_art in all_published)
-        self.assertTrue(not scheduled in all_published)
+        self.assertTrue(self.published in all_published)
+        self.assertTrue(not self.draft_art in all_published)
+        self.assertTrue(not self.scheduled in all_published)
+
+    def test_is_published(self):
+        self.assertTrue(self.published.is_published)
+        self.assertFalse(self.draft_art.is_published)
+        self.assertFalse(self.scheduled.is_published)


### PR DESCRIPTION
This is the same check that the `PublishedManager` QuerySet filter uses. But where the Manager finds published content instances, this determines published status on a content instance you already have.
