### PR TITLE
Update publication.py

### DIFF
--- a/armstrong/core/arm_content/mixins/publication.py
+++ b/armstrong/core/arm_content/mixins/publication.py
@@ -39,5 +39,5 @@ class PublishedManager(InheritanceManager):
     """ Returns published objects where the pub_date has already passed """
     def get_query_set(self):
         return super(PublishedManager, self).get_query_set()\
-                .filter(pub_date__lte=datetime.now())\
+                .filter(pub_date__lte=datetime.now)\
                 .filter(pub_status="P")


### PR DESCRIPTION
Manager should contain a reference to now, not the value of now. The value is being generated when the class is initialized, and not when the published method is being called.
